### PR TITLE
v0.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.3] - 2026-05-10
+
 ### Added
 - **README-linked assets in publish output**: `tyler build` now copies local files linked from `README.md` into the output directory, preserving paths. This supports Typst Universe documentation assets such as README images that should be committed to the registry but listed in `package.exclude` so they are left out of downloaded package archives.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **README-linked assets in publish output**: `tyler build` now copies local files linked from `README.md` into the output directory, preserving paths. This supports Typst Universe documentation assets such as README images that should be committed to the registry but listed in `package.exclude` so they are left out of downloaded package archives.
+
+### Changed
+- **Separate Tyler ignores from Typst excludes**: `package.exclude` is now preserved for Typst's archive behavior instead of being treated as a Tyler build skip list. Use `tool.tyler.ignore` for files that Tyler should not copy into `dist/`.
+
 ## [0.10.2] - 2026-05-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ bun i -g @mkpoli/tyler
 
 ## Usage
 
-It is recommended to put all your source files in a `src` directory and run Tyler from the root of your project, or you can specify a custom source directory (even the project root) with `--srcdir`. When `srcdir` is the project root, Tyler automatically skips obvious dev cruft (`.git`, `node_modules`, `.DS_Store`, `.vscode`, `.idea`, the output directory) so you don't have to enumerate them. Anything project-specific you want left out of the distributed package should go in `package.exclude` (the official Typst manifest field) or `tool.tyler.ignore` — both are honored and combined at build time.
+It is recommended to put all your source files in a `src` directory and run Tyler from the root of your project, or you can specify a custom source directory (even the project root) with `--srcdir`. When `srcdir` is the project root, Tyler automatically skips obvious dev cruft (`.git`, `node_modules`, `.DS_Store`, `.vscode`, `.idea`, the output directory) so you don't have to enumerate them. Anything project-specific that must not be copied into Tyler's output should go in `tool.tyler.ignore`. Files that should be committed to Typst Universe but excluded from the downloaded package archive, such as README images or PDFs, should go in `package.exclude`.
 
 ### Basics
 
@@ -139,24 +139,27 @@ CLI options can be checked with `tyler --help` and `tyler <command> --help` comm
 
 #### Excluding files from the published package
 
-Tyler builds an effective skip list at build time from three sources, in this order:
+Tyler builds an effective skip list at build time from two sources, in this order:
 
 1. `tool.tyler.ignore` (or `--ignore` on the CLI) — Tyler-specific patterns.
-2. `package.exclude` — the official Typst manifest field for files that must not be part of the released package.
-3. Built-in defaults — `.git`, `node_modules`, `.DS_Store`, `.vscode`, `.idea`, and the configured `outdir` when it sits inside `srcdir`.
+2. Built-in defaults — `.git`, `node_modules`, `.DS_Store`, `.vscode`, `.idea`, and the configured `outdir` when it sits inside `srcdir`.
+
+`package.exclude` is different: it is the official Typst manifest field for files that should be committed to Typst Universe but excluded from the downloaded package archive. Tyler preserves it in the generated manifest and automatically copies local files linked from `README.md` into the output directory so Universe can render the documentation correctly.
 
 Patterns are gitignore-flavoured globs (powered by `minimatch`, with `dot: true`). A literal directory name like `node_modules` matches both the directory entry itself and everything under it.
 
 #### Flat layout (library at the project root)
 
-If your library lives at the project root rather than under `src/` — a common shape for small libraries and for projects that you don't want to restructure — set `srcdir = "."` and let `package.exclude` carry your project-specific dev paths. Built-in defaults take care of `.git`, `node_modules`, the `outdir`, and friends, so you typically only need to list things like `examples/`, `scripts/`, or test fixtures.
+If your library lives at the project root rather than under `src/` — a common shape for small libraries and for projects that you don't want to restructure — set `srcdir = "."` and let `tool.tyler.ignore` carry project-specific files that Tyler should not copy. Built-in defaults take care of `.git`, `node_modules`, the `outdir`, and friends, so you typically only need to list things like build scripts or test fixtures. Use `package.exclude` for README-linked documentation assets that should be committed to Universe but left out of downloaded package archives.
 
 ```
 my-lib/
 ├── lib.typ
 ├── lib/
 │   └── helpers.typ
-├── examples/        ← dev-only
+├── manual.pdf       ← linked from README, excluded from package archive
+├── scripts/         ← dev-only
+├── tests/           ← dev-only
 ├── README.md
 ├── LICENSE
 └── typst.toml
@@ -170,10 +173,11 @@ entrypoint = "lib.typ"
 authors = ["Your Name"]
 license = "MIT"
 description = "..."
-exclude = ["examples/**"]
+exclude = ["manual.pdf"]
 
 [tool.tyler]
 srcdir = "."
+ignore = ["scripts/**", "tests/**"]
 ```
 
 For a template package with the same flat shape, keep the canonical `template/` directory next to `lib.typ` and point `template.path` at it:
@@ -185,7 +189,7 @@ entrypoint = "main.typ"
 thumbnail = "thumbnail.png"
 ```
 
-Tyler will copy everything under the project root into `dist/`, rewrite `#import "../lib.typ"` in template files to `#import "@preview/<name>:<version>"`, and skip both the built-in defaults and the patterns you listed in `package.exclude`.
+Tyler will copy everything under the project root into `dist/`, rewrite `#import "../lib.typ"` in template files to `#import "@preview/<name>:<version>"`, and skip the built-in defaults and `tool.tyler.ignore` patterns. `package.exclude` remains in the generated manifest so Typst Universe can leave those files out of the downloaded package archive.
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mkpoli/tyler",
-	"version": "0.10.2",
+	"version": "0.10.3",
 	"author": {
 		"name": "mkpoli",
 		"url": "https://mkpo.li/",

--- a/src/cli/commands/build.ts
+++ b/src/cli/commands/build.ts
@@ -37,6 +37,47 @@ import { stringifyToml } from "@/utils/manifest";
 import { execAndGetOutput, execAndRedirect } from "@/utils/process";
 import check from "./check";
 
+function stripMarkdownLinkSuffix(target: string): string {
+	const hashIndex = target.indexOf("#");
+	const queryIndex = target.indexOf("?");
+	const suffixIndexes = [hashIndex, queryIndex].filter((index) => index >= 0);
+	if (suffixIndexes.length === 0) return target;
+	return target.slice(0, Math.min(...suffixIndexes));
+}
+
+function isLocalMarkdownTarget(target: string): boolean {
+	const trimmed = target.trim();
+	if (!trimmed || trimmed.startsWith("#")) return false;
+	if (trimmed.startsWith("/")) return false;
+	if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return false;
+	return true;
+}
+
+function extractReadmeAssetPaths(readme: string): string[] {
+	const targets: string[] = [];
+	const markdownLinkPattern = /!?\[[^\]]*\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+	const htmlSrcPattern = /\b(?:src|href)=["']([^"']+)["']/gi;
+
+	for (const pattern of [markdownLinkPattern, htmlSrcPattern]) {
+		for (const match of readme.matchAll(pattern)) {
+			const rawTarget = match[1];
+			if (!rawTarget || !isLocalMarkdownTarget(rawTarget)) continue;
+
+			const target = stripMarkdownLinkSuffix(rawTarget);
+			if (!target || !isLocalMarkdownTarget(target)) continue;
+
+			try {
+				const decoded = decodeURIComponent(target);
+				if (!targets.includes(decoded)) targets.push(decoded);
+			} catch {
+				if (!targets.includes(target)) targets.push(target);
+			}
+		}
+	}
+
+	return targets;
+}
+
 export default {
 	name: "build",
 	description: "Bump the version and build a Typst package",
@@ -253,16 +294,13 @@ export default {
 		// #endregion
 
 		// #region Combine ignore patterns
-		// Tyler's effective skip list is the union of:
-		//   - tool.tyler.ignore (CLI-overridable)
-		//   - package.exclude  (the official Typst manifest field)
-		//   - sensible defaults (.git, node_modules, OS/editor metadata, outdir if nested)
-		// This lets users adopt srcdir = "." for existing repos without enumerating
-		// every dev-only path themselves.
+		// Tyler's effective skip list only controls files copied from srcdir into
+		// outdir. `package.exclude` stays in typst.toml for the Typst registry
+		// archive, but README-linked documentation assets still need to be present
+		// in the registry submission.
 		const defaultIgnores = computeDefaultIgnores(sourceDir, outputDir);
 		const effectiveIgnores = combineIgnorePatterns(
 			updatedOptions.ignore,
-			typstToml.package.exclude,
 			defaultIgnores,
 		);
 		if (effectiveIgnores.length > 0) {
@@ -432,6 +470,57 @@ export default {
 					await fs.cp(sourceFilePath, outputFilePath, { recursive: true });
 					console.info(
 						`[Tyler] Copied ${chalk.green(path.relative(workingDirectory, sourceFilePath))} to ${chalk.yellow(path.relative(workingDirectory, outputFilePath))}`,
+					);
+				}
+			}
+		}
+		// #endregion
+
+		// #region Copy README-linked assets
+		const readmePath = path.resolve(workingDirectory, "README.md");
+		if (await fileExists(readmePath)) {
+			const readme = await fs.readFile(readmePath, "utf8");
+			for (const assetPath of extractReadmeAssetPaths(readme)) {
+				const sourceFilePath = path.resolve(workingDirectory, assetPath);
+				const relativeSourceFilePath = path.relative(
+					workingDirectory,
+					sourceFilePath,
+				);
+
+				if (
+					relativeSourceFilePath.startsWith("..") ||
+					path.isAbsolute(relativeSourceFilePath)
+				) {
+					console.warn(
+						`[Tyler] README.md links ${chalk.yellow(assetPath)}, which is outside the package root and cannot be copied`,
+					);
+					continue;
+				}
+
+				if (!(await fileExists(sourceFilePath))) {
+					console.warn(
+						`[Tyler] README.md links ${chalk.yellow(assetPath)}, but the file does not exist`,
+					);
+					continue;
+				}
+
+				const outputFilePath = path.resolve(outputDir, relativeSourceFilePath);
+				const relativeOutputFilePath = path.relative(
+					workingDirectory,
+					outputFilePath,
+				);
+
+				if (sourceFilePath === outputFilePath) continue;
+
+				if (options.dryRun) {
+					console.info(
+						`[Tyler] ${chalk.gray("(dry-run)")} Would copy README-linked asset ${chalk.green(relativeSourceFilePath)} to ${chalk.yellow(relativeOutputFilePath)}`,
+					);
+				} else {
+					await fs.mkdir(path.dirname(outputFilePath), { recursive: true });
+					await fs.cp(sourceFilePath, outputFilePath, { recursive: true });
+					console.info(
+						`[Tyler] Copied README-linked asset ${chalk.green(relativeSourceFilePath)} to ${chalk.yellow(relativeOutputFilePath)}`,
 					);
 				}
 			}

--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -586,7 +586,7 @@ export default {
 					)}`,
 				);
 				console.info(
-					"[Tyler] These patterns will be skipped at build time alongside tool.tyler.ignore",
+					"[Tyler] These patterns will be kept in typst.toml for the Typst package archive",
 				);
 			}
 		}

--- a/src/utils/ignore.ts
+++ b/src/utils/ignore.ts
@@ -65,7 +65,7 @@ export function computeDefaultIgnores(
 	return [...new Set(defaults)];
 }
 
-/** Union of user `ignore`, manifest `package.exclude`, and computed defaults. */
+/** Union of ignore pattern lists while preserving first-seen order. */
 export function combineIgnorePatterns(
 	...lists: (readonly string[] | undefined)[]
 ): string[] {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes – v0.10.3

* **New Features**
  * `tyler build` now copies README-linked local assets into the output for registry documentation rendering

* **Behavior Changes**
  * `package.exclude` is now preserved in generated manifests for Typst archive control; use `tool.tyler.ignore` for Tyler's file skipping

* **Documentation**
  * Clarified file exclusion behavior and updated configuration examples

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mkpoli/tyler/pull/2)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->